### PR TITLE
Allow blessed callbacks

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,11 +13,13 @@ requires 'Net::SSLeay'    => 1.35;
 requires 'Time::Piece'    => 1.20;
 requires 'HTTP::Request::Common'   => 6.04;
 requires 'Data::Recursive::Encode' => 0.04;
+requires 'Scalar::Util'   => 0;
 
 tests 't/*.t';
 author_tests 'xt';
 
 test_requires 'Test::More' => 0.98;
+test_requires 'Test::Fatal' => 0;
 auto_set_repository;
 auto_include;
 WriteAll;

--- a/lib/AnyEvent/Twitter.pm
+++ b/lib/AnyEvent/Twitter.pm
@@ -14,6 +14,7 @@ use Time::Piece;
 use AnyEvent::HTTP;
 use HTTP::Request::Common 'POST';
 use Data::Recursive::Encode;
+use Scalar::Util 'reftype';
 
 use Net::OAuth;
 use Net::OAuth::ProtectedResourceRequest;
@@ -79,7 +80,7 @@ sub request {
     my $url_base = $RESOURCE_URL_BASE{ $self->{api_version} };
     my $url = $opt{url} || sprintf $url_base, $opt{api};
 
-    ref $cb eq 'CODE'
+    ref $cb && reftype $cb eq 'CODE'
         or Carp::croak "callback coderef is required";
 
     my $params = $opt{params} || {};
@@ -175,7 +176,7 @@ sub get_request_token {
         defined $args{$item} or Carp::croak "$item is required";
     }
 
-    ref $args{cb} eq 'CODE'
+    ref $args{cb} && reftype $args{cb} eq 'CODE'
         or Carp::croak "cb must be callback coderef";
 
     $args{auth} ||= 'authorize';
@@ -211,7 +212,7 @@ sub get_access_token {
         defined $args{$item} or Carp::croak "$item is required";
     }
 
-    ref $args{cb} eq 'CODE'
+    ref $args{cb} && reftype $args{cb} eq 'CODE'
         or Carp::croak "cb must be callback coderef";
 
     my $req = __PACKAGE__->_make_oauth_request(

--- a/t/code-ref.t
+++ b/t/code-ref.t
@@ -1,0 +1,70 @@
+use strict;
+use Test::More;
+use Test::Fatal;
+use AnyEvent::Twitter;
+
+{
+    my $ua = AnyEvent::Twitter->new(
+        consumer_key        => 'consumer_key',
+        consumer_secret     => 'consumer_secret',
+        access_token        => 'access_token',
+        access_token_secret => 'access_token_secret',
+    );
+
+    # mock up a Twitter response
+    local *AnyEvent::HTTP::http_request = sub {
+        my $cb = pop;
+        $cb->("{}", { Status => 200, Reason => 'OK' });
+    };
+
+    like(
+        exception { $ua->get('account/verify_credentials', undef) },
+        qr/callback coderef is required/,
+        'dies with an undefined callback'
+    );
+
+    like(
+        exception { $ua->get('account/verify_credentials', {}) },
+        qr/callback coderef is required/,
+        'dies with a non-CODE callback'
+    );
+
+    is(
+        exception { $ua->get('account/verify_credentials', sub {}) },
+        undef,
+        'lives with a plain CODE callback'
+    );
+
+    is(
+        exception { $ua->get('account/verify_credentials', bless sub {}, 'Foo') },
+        undef,
+        'lives with a blessed CODE callback'
+    );
+
+    is(
+        exception {
+            AnyEvent::Twitter->get_request_token(
+                consumer_key    => 'consumer_key',
+                consumer_secret => 'consumer_secret',
+                callback_url    => 'oob',
+                cb => bless sub {}, 'Foo'
+            );
+        }, undef, 'get_request_token accepts a blessed CODE ref'
+    );
+
+    is(
+        exception {
+            AnyEvent::Twitter->get_access_token(
+                consumer_key       => 'consumer_key',
+                consumer_secret    => 'consumer_secret',
+                oauth_token        => 'token',
+                oauth_token_secret => 'secret',
+                oauth_verifier     => 'pin',
+                cb => bless sub {}, 'Foo'
+            );
+        }, undef, 'get_access_token accepts a blessed CODE ref'
+    );
+}
+
+done_testing;
+


### PR DESCRIPTION
This minor change allows passing blessed CODE refs as callbacks. E.g.,
those created by [POE::Session](https://metacpan.org/pod/POE::Session)'s [postback](https://metacpan.org/pod/POE::Session#postback-EVENT_NAME-EVENT_PARAMETERS) and [callback](https://metacpan.org/pod/POE::Session#callback-EVENT_NAME-EVENT_PARAMETERS) methods:

Thanks for your work on `AnyEvent::Twitter`!
